### PR TITLE
Upgrade MCP transport from SSE to Streamable HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,16 @@ Add to your project's `.mcp.json` (or `~/.claude/settings.json`):
 }
 ```
 
-#### SSE (remote -- connects to a running server)
+#### Streamable HTTP (remote -- connects to a running server)
 
-When the glitchbox server is already running, the SSE endpoint is available automatically. Add to `.mcp.json`:
+When the glitchbox server is already running, the MCP endpoint is available automatically. Add to `.mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "glitchbox": {
-      "type": "sse",
-      "url": "http://<host>:7860/mcp/sse"
+      "type": "streamable-http",
+      "url": "http://<host>:7860/mcp/"
     }
   }
 }

--- a/server/main.py
+++ b/server/main.py
@@ -55,12 +55,13 @@ except ImportError as e:
 
 # Import MCP server
 try:
-    from mcp_server import mount_mcp_sse
+    from mcp_server import mcp as mcp_server, mount_mcp_http
     MCP_AVAILABLE = True
 except ImportError as e:
     print(f"[main.py] Warning: MCP import failed: {e}")
     print("[main.py] MCP server will not be available")
     MCP_AVAILABLE = False
+    mcp_server = None
 
 # import pycuda.driver as cuda
 
@@ -356,10 +357,10 @@ class App:
 
         self.init_app()
 
-        # Mount MCP SSE server if available
+        # Mount MCP Streamable HTTP server if available
         if MCP_AVAILABLE:
-            mount_mcp_sse(self.app)
-            print("[main.py] MCP SSE server mounted at /mcp/")
+            mount_mcp_http(self.app)
+            print("[main.py] MCP Streamable HTTP server mounted at /mcp/")
 
     async def warmup_all_pipes(self):
         """Warmup all pipes by making dummy predictions to pre-trace computational graphs"""
@@ -469,6 +470,12 @@ class App:
                 await self.image_saver.start()
                 print("[main.py] Image saver started")
 
+            # Start MCP session manager if available
+            if MCP_AVAILABLE and mcp_server:
+                self._mcp_session_cm = mcp_server.session_manager.run()
+                await self._mcp_session_cm.__aenter__()
+                print("[main.py] MCP session manager started")
+
             # Start gRPC server if enabled
             if self.grpc_server:
                 self.grpc_server.start()
@@ -526,6 +533,11 @@ class App:
         async def shutdown_event():
             # Shutdown
             print("Application shutdown")
+
+            # Stop MCP session manager if running
+            if MCP_AVAILABLE and hasattr(self, '_mcp_session_cm'):
+                await self._mcp_session_cm.__aexit__(None, None, None)
+                print("[main.py] MCP session manager stopped")
 
             # Stop gRPC server if running
             if self.grpc_server:

--- a/server/mcp_server/__init__.py
+++ b/server/mcp_server/__init__.py
@@ -1,6 +1,6 @@
 """MCP server module for Glitchbox generation control."""
 
 from .server import mcp
-from .sse import mount_mcp_sse
+from .sse import mount_mcp_http
 
-__all__ = ["mcp", "mount_mcp_sse"]
+__all__ = ["mcp", "mount_mcp_http"]

--- a/server/mcp_server/sse.py
+++ b/server/mcp_server/sse.py
@@ -1,4 +1,4 @@
-"""SSE transport mount for embedding the MCP server in a FastAPI/Starlette app."""
+"""Streamable HTTP transport mount for embedding the MCP server in a FastAPI/Starlette app."""
 
 from starlette.applications import Starlette
 from starlette.routing import Mount
@@ -6,11 +6,14 @@ from starlette.routing import Mount
 from .server import mcp
 
 
-def mount_mcp_sse(app: Starlette) -> None:
-    """Mount the MCP SSE transport on a FastAPI/Starlette app at /mcp/.
+def mount_mcp_http(app: Starlette) -> None:
+    """Mount the MCP Streamable HTTP transport on a FastAPI/Starlette app at /mcp/.
 
-    Endpoints:
-        GET  /mcp/sse        -- SSE event stream (client connects here)
-        POST /mcp/messages/  -- client sends messages here
+    Endpoint:
+        POST /mcp/mcp  -- Streamable HTTP endpoint (client connects here)
+
+    The session manager must be started separately via
+    ``mcp.session_manager.run()`` during the application lifespan.
     """
-    app.mount("/mcp", Mount(path="", app=mcp.sse_app()))
+    mcp.settings.streamable_http_path = "/"
+    app.mount("/mcp", Mount(path="", app=mcp.streamable_http_app()))


### PR DESCRIPTION
Replaces the deprecated SSE transport with the modern Streamable HTTP transport for the MCP server. Endpoint changes from /mcp/sse to /mcp/.